### PR TITLE
Dockerfile: Remove unnecessary python-pbs dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get -q update && \
     cp -rf /root/custom_zulip/* /root/zulip && \
     rm -rf /root/custom_zulip && \
     PUPPET_CLASSES="zulip::dockervoyager" DEPLOYMENT_TYPE="dockervoyager" \
-    ADDITIONAL_PACKAGES="python-dev python-six python-pbs python-crypto rabbitmq-server expect" \
+    ADDITIONAL_PACKAGES="python-dev python-six python-crypto rabbitmq-server expect" \
     /root/zulip/scripts/setup/install && \
     cp -a /root/zulip/zproject/prod_settings_template.py /etc/zulip/settings.py && \
     ln -nsf /etc/zulip/settings.py /root/zulip/zproject/prod_settings.py && \


### PR DESCRIPTION
This hasn't been a dependency of Zulip's provision for over a year.
https://github.com/zulip/zulip/commit/eeb5302ba1e1a8db786c695774060cf878f4421c