### PR TITLE
resurrect DISABLE_HTTPS option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends && \
 
 COPY includes/createZulipRealm.sh /opt/createZulipRealm.sh
 COPY entrypoint.sh /sbin/entrypoint.sh
+ADD setup_files/ /opt/files
 
 RUN chown zulip:zulip /opt/createZulipRealm.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ if [ -z "$SETTING_MEMCACHED_LOCATION" ]; then
     SETTING_MEMCACHED_LOCATION="127.0.0.1:11211"
 fi
 # Nginx settings
+DISABLE_HTTPS="${DISABLE_HTTPS:-false}"
 NGINX_WORKERS="${NGINX_WORKERS:-2}"
 NGINX_PROXY_BUFFERING="${NGINX_PROXY_BUFFERING:-off}"
 NGINX_MAX_UPLOAD_SIZE="${NGINX_MAX_UPLOAD_SIZE:-24m}"
@@ -151,6 +152,10 @@ setConfigurationValue() {
 }
 nginxConfiguration() {
     echo "Executing nginx configuration ..."
+    if [ "$DISABLE_HTTPS" == "True" ] || [ "$DISABLE_HTTPS" == "true" ]; then
+        echo "Disabling https in nginx."
+        mv -f /opt/files/nginx/zulip-enterprise-http /etc/nginx/sites-enabled/zulip-enterprise
+    fi
     sed -i "s/worker_processes .*/worker_processes $NGINX_WORKERS;/g" /etc/nginx/nginx.conf
     sed -i "s/client_max_body_size .*/client_max_body_size $NGINX_MAX_UPLOAD_SIZE;/g" /etc/nginx/nginx.conf
     sed -i "s/proxy_buffering .*/proxy_buffering $NGINX_PROXY_BUFFERING;/g" /etc/nginx/zulip-include/proxy_longpolling

--- a/setup_files/nginx/zulip-enterprise-http
+++ b/setup_files/nginx/zulip-enterprise-http
@@ -1,0 +1,22 @@
+
+include /etc/nginx/zulip-include/upstreams;
+
+server {
+    listen 80;
+
+    location /user_avatars {
+        add_header X-Content-Type-Options nosniff;
+        add_header Content-Security-Policy "default-src 'none' img-src 'self'";
+        include /etc/nginx/zulip-include/uploads.types;
+        alias /home/zulip/uploads/avatars;
+    }
+
+    location /local-static {
+        alias /home/zulip/local-static;
+    }
+
+    include /etc/nginx/zulip-include/certbot;
+    include /etc/nginx/zulip-include/app;
+    include /etc/nginx/zulip-include/uploads.route;
+}
+


### PR DESCRIPTION
There used to be a DISABLE_HTTPS setting.   I'm not sure why it was removed, but I need it so I can use Zulip behind a Kubernetes Ingress without causing an infinite redirect.