### PR TITLE
kubernetes: Fix hostnames in the zulip pod.

### DIFF
--- a/kubernetes/zulip-rc.yml
+++ b/kubernetes/zulip-rc.yml
@@ -49,11 +49,11 @@ spec:
             cpu: 80m
             memory: 768Mi
         env:
-        - name: DB_NAME
+        - name: POSTGRES_DB
           value: zulip
-        - name: DB_USER
+        - name: POSTGRES_USER
           value: zulip
-        - name: DB_PASS
+        - name: POSTGRES_PASSWORD
           value: zulip
         volumeMounts:
           - name: postgresql-persistent-storage
@@ -67,13 +67,13 @@ spec:
         env:
         # Please take a look at the environment variables in docker-compose.yml for all required env variables!
         - name: DB_HOST
-          value: "database"
+          value: "localhost"
         - name: MEMCACHED_HOST
-          value: "memcached"
+          value: "localhost"
         - name: REDIS_HOST
-          value: "redis"
+          value: "localhost"
         - name: RABBITMQ_HOST
-          value: "rabbitmq"
+          value: "localhost"
         - name: ZULIP_AUTH_BACKENDS
           value: "EmailAuthBackend"
         - name: SECRETS_email_password


### PR DESCRIPTION
All of the containers are running on a single pod so we can use
localhost to connect to the other services. After this change database
migrations are completing and the app server is starting. It seems
rabbit MQ is still failing to run correctly.